### PR TITLE
Updated CMakeLists.txt to link to the indigo version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/hydro/share/catkin/cmake/toplevel.cmake
+/opt/ros/indigo/share/catkin/cmake/toplevel.cmake


### PR DESCRIPTION
This is a very simple change that fixes the CMakeLists.txt file link to point to the indigo version of ROS, instead of hydro. The main goal of this pull request is to test the process for future changes.
